### PR TITLE
Updated Podfile and info.plist to allow the demo app to work properly

### DIFF
--- a/MapTileAnimationDemo/MapTileAnimationDemo/MapTileAnimationDemo-Info.plist
+++ b/MapTileAnimationDemo/MapTileAnimationDemo/MapTileAnimationDemo-Info.plist
@@ -2,6 +2,11 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+	<key>NSAppTransportSecurity</key>
+	<dict>
+		<key>NSAllowsArbitraryLoads</key>
+		<true/>
+	</dict>
 	<key>CFBundleDevelopmentRegion</key>
 	<string>en</string>
 	<key>CFBundleDisplayName</key>

--- a/MapTileAnimationDemo/Podfile
+++ b/MapTileAnimationDemo/Podfile
@@ -1,5 +1,7 @@
 source 'https://github.com/CocoaPods/Specs.git'
 
-target 'MapTileAnimationDemo', :exclusive => true do
+platform :ios, '7.0'
+
+target 'MapTileAnimationDemo' do
   pod "TCCMapTileAnimation", :path => "../"
 end


### PR DESCRIPTION
The Podfile in the Demo app hasn't been updated in quite some time, and iOS now requires an additional key in the app's info.plist in order to make http requests.  
  
This pull requests updates the Podfile to play nice with Cocoapods version 1.5.3 and adds the `NSAppTransportSecurity` key and sets it's `NSAllowsArbitraryLoads` property to `true` so that it can make requests to the map tiling server.