### PR TITLE
Data race fix

### DIFF
--- a/Pod/Public/TCCAnimationTileOverlayRenderer.h
+++ b/Pod/Public/TCCAnimationTileOverlayRenderer.h
@@ -14,7 +14,7 @@
  Zoom level of the currently rendered overlay tiles. Value ranges from 1-20. Useful to
  fetch the tiles with the correct zoom level for the animation overlay.
  */
-@property (readonly, nonatomic) NSUInteger renderedTileZoomLevel;
+@property (readonly, atomic) NSUInteger renderedTileZoomLevel;
 
 @property (nonatomic) BOOL drawDebugInfo;
 

--- a/Pod/Public/TCCAnimationTileOverlayRenderer.m
+++ b/Pod/Public/TCCAnimationTileOverlayRenderer.m
@@ -12,7 +12,7 @@
 #import "TCCMapKitHelpers.h"
 
 @interface TCCAnimationTileOverlayRenderer ()
-@property (readwrite, nonatomic) NSUInteger renderedTileZoomLevel;
+@property (readwrite, atomic) NSUInteger renderedTileZoomLevel;
 @end
 
 @implementation TCCAnimationTileOverlayRenderer


### PR DESCRIPTION
When using TCCAnimationTileOverlayRenderer in a multi-threaded environment renderedTileZoomLevel must read/write atomically.