### PR TITLE
The tile from a NSCache is nil in a case of low memory.

### DIFF
--- a/Pod/Public/TCCAnimationTileOverlayRenderer.m
+++ b/Pod/Public/TCCAnimationTileOverlayRenderer.m
@@ -84,8 +84,9 @@ int const TCCTileSize = 256; // on iOS 12 and earlier, all tiles are 256. in 13,
             while (tileCol < widthCount) {
                                 
                 MKMapRect localMapRect = MKMapRectMake(mapRect.origin.x + (tileCol * tileSizeForZoomLevel), mapRect.origin.y + (tileRow * tileSizeForZoomLevel), tileSizeForZoomLevel, tileSizeForZoomLevel);
-                
-                TCCAnimationTile *tile = [animationOverlay staticTileForMapRect:localMapRect zoomLevel:cappedZoomLevel];
+
+                //The tile can be nil in a case of low memory
+                __weak __typeof__(TCCAnimationTile *) tile = [animationOverlay staticTileForMapRect:localMapRect zoomLevel:cappedZoomLevel];
                 
                 // Draw the image if we have it, otherwise load the tile data. Returning NO will make sure that
                 // drawRect doesn't get called immediately until setNeedsDisplayInMapRect:zoomScale: gets called

--- a/TCCMapTileAnimation.podspec
+++ b/TCCMapTileAnimation.podspec
@@ -9,7 +9,7 @@
 
 Pod::Spec.new do |s|
   s.name             = "TCCMapTileAnimation"
-  s.version          = "0.4.16"
+  s.version          = "0.4.17"
   s.summary          = "A library for creating animated map overlays from tiles"
   s.homepage         = "https://github.com/TheClimateCorporation/TCCMapTileAnimation"
   s.license          = 'Apache v2'

--- a/TCCMapTileAnimation.podspec
+++ b/TCCMapTileAnimation.podspec
@@ -9,7 +9,7 @@
 
 Pod::Spec.new do |s|
   s.name             = "TCCMapTileAnimation"
-  s.version          = "0.4.17"
+  s.version          = "0.4.16"
   s.summary          = "A library for creating animated map overlays from tiles"
   s.homepage         = "https://github.com/TheClimateCorporation/TCCMapTileAnimation"
   s.license          = 'Apache v2'

--- a/TCCMapTileAnimation.podspec
+++ b/TCCMapTileAnimation.podspec
@@ -9,7 +9,7 @@
 
 Pod::Spec.new do |s|
   s.name             = "TCCMapTileAnimation"
-  s.version          = "0.4.15"
+  s.version          = "0.4.16"
   s.summary          = "A library for creating animated map overlays from tiles"
   s.homepage         = "https://github.com/TheClimateCorporation/TCCMapTileAnimation"
   s.license          = 'Apache v2'


### PR DESCRIPTION
The func staticTileForMapRect returns a tile from the NSCache object which can release data inside and return nil in the case of low memory.

"The NSCache object is a “reactive cache.” That is, when memory is available, it aggressively caches any data it is given. Yet, when memory is low, it will automatically discard some of its elements in order to free up memory for other applications." - from apple documents
https://developer.apple.com/library/archive/documentation/Performance/Conceptual/ManagingMemory/Articles/CachingandPurgeableMemory.html#//apple_ref/doc/uid/TP40013104-SW1