### PR TITLE
Fixed the EXC_BAD_ACCESS exception for the overlay obj.

### DIFF
--- a/Pod/Public/TCCAnimationTileOverlayRenderer.m
+++ b/Pod/Public/TCCAnimationTileOverlayRenderer.m
@@ -42,11 +42,11 @@ int const TCCTileSize = 256; // on iOS 12 and earlier, all tiles are 256. in 13,
 
 - (BOOL)canDrawMapRect:(MKMapRect)mapRect zoomScale:(MKZoomScale)zoomScale
 {
-    self.renderedTileZoomLevel = [TCCMapKitHelpers zoomLevelForZoomScale:zoomScale];
-    
-    TCCAnimationTileOverlay *animationOverlay = (TCCAnimationTileOverlay *)self.overlay;
-    
     __weak TCCAnimationTileOverlayRenderer * weakSelf = self;
+    weakSelf.renderedTileZoomLevel = [TCCMapKitHelpers zoomLevelForZoomScale:zoomScale];
+
+    //The overlay can be nil if often or quickly to dealloc the renderer.
+    __weak __typeof__(TCCAnimationTileOverlay *) animationOverlay = weakSelf.overlay;
     
     // Render static tiles if we're stopped. Uses the MKTileOverlay method loadTileAtPath:result:
     // to load and render tile images asynchronously and on demand.


### PR DESCRIPTION
Fixed EXC_BAD_ACCESS KERN_INVALID_ADDRESS reported in the Crashlytics.

`Crashed: com.apple.mapdisplay.dispatch.overlaytiledecodequeue
0  libobjc.A.dylib                0x1bcda2624 objc_initWeak + 148
1  TCCMapTileAnimation            0x102035e68 -[TCCAnimationTileOverlayRenderer canDrawMapRect:zoomScale:] + 53 (TCCAnimationTileOverlayRenderer.m:53)
2  MapKit                         0x1ca956ed4 __40-[MKOverlayRenderer overlay:canDrawKey:]_block_invoke + 256
3  MapKit                         0x1ca956bd8 __68-[MKOverlayRenderer _forEachMapRectForKey:withContext:performBlock:]_block_invoke + 496
4  MapKit                         0x1ca956980 -[MKOverlayRenderer _forEachMapRectForKey:withContext:performBlock:] + 200
5  MapKit                         0x1ca7a2004 -[MKOverlayRenderer overlay:canDrawKey:] + 168
6  VectorKit                      0x1cb388280 _processOverlays(geo::MercatorTile const&, unsigned int, float, VKSharedResources const*, ggl::Loader&, std::__1::vector<geo::_retain_ptr<VKOverlay*, geo::_retain_objc, geo::_release_objc, geo::_hash_objc, geo::_equal_objc>, std::__1::allocator<geo::_retain_ptr<VKOverlay*, geo::_retain_objc, geo::_release_objc, geo::_hash_objc, geo::_equal_objc> > > const&, std::__1::vector<md::OverlayTileData::OverlayTileResource, std::__1::allocator<md::OverlayTileData::OverlayTileResource> >&, std::__1::shared_ptr<ggl::ConstantDataTyped<ggl::Tile::View> >) + 524
7  VectorKit                      0x1cb387e0c md::OverlayLayerDataSource::createLayerData(mdc::LayerDataRequestKey const&, geo::linear_map<unsigned short, std::__1::unordered_map<mdc::ResourceKey, std::__1::shared_ptr<mdc::Resource>, mdc::ResourceKeyHash, std::__1::equal_to<mdc::ResourceKey>, std::__1::allocator<std::__1::pair<mdc::ResourceKey const, std::__1::shared_ptr<mdc::Resource> > > >, std::__1::equal_to<unsigned short>, std::__1::allocator<std::__1::pair<unsigned short, std::__1::unordered_map<mdc::ResourceKey, std::__1::shared_ptr<mdc::Resource>, mdc::ResourceKeyHash, std::__1::equal_to<mdc::ResourceKey>, std::__1::allocator<std::__1::pair<mdc::ResourceKey const, std::__1::shared_ptr<mdc::Resource> > > > > >, std::__1::vector<std::__1::pair<unsigned short, std::__1::unordered_map<mdc::ResourceKey, std::__1::shared_ptr<mdc::Resource>, mdc::ResourceKeyHash, std::__1::equal_to<mdc::ResourceKey>, std::__1::allocator<std::__1::pair<mdc::ResourceKey const, std::__1::shared_ptr<mdc::Resource> > > > >, std::__1::allocator<std::__1::pair<unsigned short, std::__1::unordered_map<mdc::ResourceKey, std::__1::shared_ptr<mdc::Resource>, mdc::ResourceKeyHash, std::__1::equal_to<mdc::ResourceKey>, std::__1::allocator<std::__1::pair<mdc::ResourceKey const, std::__1::shared_ptr<mdc::Resource> > > > > > > > const&, long long) const + 232
8  VectorKit                      0x1cb5be34c mdc::LayerDataSource::updateLayerData(unsigned long, mdc::LayerDataRequestKey const&, geo::linear_map<unsigned short, std::__1::unordered_map<mdc::ResourceKey, std::__1::shared_ptr<mdc::Resource>, mdc::ResourceKeyHash, std::__1::equal_to<mdc::ResourceKey>, std::__1::allocator<std::__1::pair<mdc::ResourceKey const, std::__1::shared_ptr<mdc::Resource> > > >, std::__1::equal_to<unsigned short>, std::__1::allocator<std::__1::pair<unsigned short, std::__1::unordered_map<mdc::ResourceKey, std::__1::shared_ptr<mdc::Resource>, mdc::ResourceKeyHash, std::__1::equal_to<mdc::ResourceKey>, std::__1::allocator<std::__1::pair<mdc::ResourceKey const, std::__1::shared_ptr<mdc::Resource> > > > > >, std::__1::vector<std::__1::pair<unsigned short, std::__1::unordered_map<mdc::ResourceKey, std::__1::shared_ptr<mdc::Resource>, mdc::ResourceKeyHash, std::__1::equal_to<mdc::ResourceKey>, std::__1::allocator<std::__1::pair<mdc::ResourceKey const, std::__1::shared_ptr<mdc::Resource> > > > >, std::__1::allocator<std::__1::pair<unsigned short, std::__1::unordered_map<mdc::ResourceKey, std::__1::shared_ptr<mdc::Resource>, mdc::ResourceKeyHash, std::__1::equal_to<mdc::ResourceKey>, std::__1::allocator<std::__1::pair<mdc::ResourceKey const, std::__1::shared_ptr<mdc::Resource> > > > > > > > const&, long long) + 92
9  VectorKit                      0x1cb5c1f2c std::__1::__function::__func<mdc::LayerDataSource::processLayerDataRequests(mdc::ResourceManager*, geo::TaskGroup*, long long)::$_5, std::__1::allocator<mdc::LayerDataSource::processLayerDataRequests(mdc::ResourceManager*, geo::TaskGroup*, long long)::$_5>, void ()>::operator()() + 156
10 VectorKit                      0x1cb541a9c invocation function for block in geo::TaskQueue::queueAsyncTask(std::__1::shared_ptr<geo::Task>, NSObject<OS_dispatch_group>*) + 80
11 libdispatch.dylib              0x1bcd2c610 _dispatch_call_block_and_release + 24
12 libdispatch.dylib              0x1bcd2d184 _dispatch_client_callout + 16
13 libdispatch.dylib              0x1bccd9404 _dispatch_lane_serial_drain$VARIANT$mp + 608
14 libdispatch.dylib              0x1bccd9e28 _dispatch_lane_invoke$VARIANT$mp + 468
15 libdispatch.dylib              0x1bcce3314 _dispatch_workloop_worker_thread + 588
16 libsystem_pthread.dylib        0x1bcd7cf88 _pthread_wqthread + 276
17 libsystem_pthread.dylib        0x1bcd7fad4 start_wqthread + 8`